### PR TITLE
Split Windows and Linux build script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ jobs:
     pool:
       vmImage: 'ubuntu 16.04'
     steps:
-      - template: ci/build-template.yml
+      - template: ci/build-linux.yml
         parameters:
           url: https://github.com/ldc-developers/ldc/releases/download/v1.14.0/ldc2-1.14.0-linux-x86_64.tar.xz
           bindir: ldc/ldc2-1.14.0-linux-x86_64/bin
@@ -15,7 +15,7 @@ jobs:
     pool:
       vmImage: 'vs2017-win2016'
     steps:
-      - template: ci/build-template.yml
+      - template: ci/build-windows.yml
         parameters:
           url: https://github.com/ldc-developers/ldc/releases/download/v1.14.0/ldc2-1.14.0-windows-x64.7z
           bindir: ldc\ldc2-1.14.0-windows-x64\bin

--- a/ci/build-linux.yml
+++ b/ci/build-linux.yml
@@ -1,0 +1,24 @@
+parameters:
+  url: ''
+  bindir: ''
+  archive: ''
+  binary:   ''
+
+steps:
+  - bash: wget -O ${{ parameters.archive }} ${{ parameters.url }}
+    displayName: Download compiler package
+
+  - task: ExtractFiles@1
+    inputs:
+      archiveFilePatterns: ${{ parameters.archive }}
+      destinationFolder: 'ldc'
+
+  - bash: |
+      ${{ parameters.bindir }}/dub test -a x86_64
+      ${{ parameters.bindir }}/dub build -a x86_64
+    displayName: Build application
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: ${{ parameters.binary }}
+      artifactName: dc

--- a/ci/build-windows.yml
+++ b/ci/build-windows.yml
@@ -11,7 +11,6 @@ steps:
       platform: x64
       configuration: Release
     displayName: Build 7z SDK
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
 
   - powershell: wget -O ${{ parameters.archive }} ${{ parameters.url }}
     displayName: Download compiler package
@@ -21,20 +20,13 @@ steps:
       archiveFilePatterns: ${{ parameters.archive }}
       destinationFolder: 'ldc'
 
-  - script: ci\windows.bat
-    env:
-      bindir: ${{ parameters.bindir }}
-    displayName: Build application (Windows)
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
-
-  - script: ci/linux.sh
-    env:
-      bindir: ${{ parameters.bindir }}
-    displayName: Build application (Linux)
-    condition: eq(variables['Agent.OS'], 'Linux')
+  - script: |
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+      ${{ parameters.bindir }}\dub test -a x86_64
+      ${{ parameters.bindir }}\dub build -a x86_64
+    displayName: Build application
 
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: ${{ parameters.binary }}
       artifactName: dc
-

--- a/ci/linux.sh
+++ b/ci/linux.sh
@@ -1,2 +1,0 @@
-$bindir/dub test -a x86_64
-$bindir/dub build -a x86_64

--- a/ci/windows.bat
+++ b/ci/windows.bat
@@ -1,3 +1,0 @@
-call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-%bindir%\dub test -a x86_64
-%bindir%\dub build -a x86_64


### PR DESCRIPTION
There are too many platform specific bits to put any effort into
maintaining single build definition right now.