### PR TITLE
Rework how added files are tracked

### DIFF
--- a/source/dc/app.d
+++ b/source/dc/app.d
@@ -58,6 +58,7 @@ void main (string[] args)
         info("COMMAND: action to perform");
         info("\tuse - switch to specified compiler, disabling the current one if present");
         info("\tfetch - download specified compiler distribution without affecting the current one");
+        info("\tdisable - disable currently used compiler (but keep distribution archive)");
         info("");
         info("COMPILER: compiler description string");
         info("\tdmd-2.099.9 - example, describes DMD compiler of version 2.099.9");

--- a/source/dc/compilers/api.d
+++ b/source/dc/compilers/api.d
@@ -9,6 +9,8 @@ import dc.utils.path : Path;
  */
 abstract class Compiler
 {
+    import dc.compilers.common;
+
     /// Downloads compiler and stored in the sandbox cache
     void fetch ();
 
@@ -21,7 +23,7 @@ abstract class Compiler
     /// Standard text representation of this compiler description
     string representation ()
     {
-        return this.name ~ "-" ~ this.ver;
+        return this.config.name ~ "-" ~ this.config.ver;
     }
 
     ///
@@ -34,16 +36,37 @@ abstract class Compiler
     }
 
     ///
-    this (Path root, string name, string ver)
+    this (Config config)
     {
-        this.root = root;
-        this.name = name;
-        this.ver = ver;
+        this.config = config;
+
+        this.distribution = CompilerDistribution(
+            this.representation()
+        );
+    }
+
+    ///
+    final void registerExistingFiles (Path[] files)
+    {
+        this.distribution.registerExistingFiles(files);
     }
 
     protected {
-        Path root;
-        string name;
-        string ver;
+        struct Config
+        {
+            /// root of whole toolchain directory
+            Path root;
+            /// path to extracted compiler distribution directory
+            Path source;
+            /// path to downloaded compiler distribution archive
+            Path archive;
+            /// compiler name (dmd|ldc|gdc)
+            string name;
+            /// compiler version string, i.e. "2.080.0"
+            string ver;
+        }
+
+        Config config;
+        CompilerDistribution distribution;
     }
 }

--- a/source/dc/compilers/package.d
+++ b/source/dc/compilers/package.d
@@ -13,7 +13,7 @@ import dc.utils.path : Path;
     Returns:
         instance capable of manipulating compiler distribution
  */
-Compiler compiler (string description, Path root)
+Compiler compilerFromDescription (string description, Path root)
 {
     import std.format : formattedRead;
     import dc.compilers.dmd;
@@ -33,4 +33,30 @@ Compiler compiler (string description, Path root)
         default:
             throw new DcException("Unsupported compiler", "");
     }
+}
+
+/**
+    Creates a new compiler management object based on a
+    'USED' anchor file present in existing installation.
+
+    Params:
+        anchor = path to 'USED' file
+
+    Returns:
+        instance capable of manipulating compiler distribution
+ */
+Compiler compilerFromAnchor (Path anchor, Path root)
+{
+    import std.stdio : File;
+    import std.algorithm : map;
+    import std.string : strip;
+    import std.array;
+
+    auto lines = File(anchor).byLineCopy.array();
+    auto description = lines[0];
+
+    auto compiler = compilerFromDescription(description, root);
+    compiler.registerExistingFiles(
+        lines[1 .. $].map!(line => Path(strip(line))).array());
+    return compiler;
 }

--- a/source/dc/dc.d
+++ b/source/dc/dc.d
@@ -47,20 +47,23 @@ public class HelpMsgException : Exception
  */
 ActionContext parseAction (string[] args)
 {
-    if (args.length != 2)
-        throw new HelpMsgException;
+    import std.exception;
 
-    auto action = () {
-        switch (args[0])
-        {
-            case "use":   return (Action.Fetch | Action.Disable | Action.Enable);
-            case "fetch": return Action.Fetch;
+    enforce!HelpMsgException(args.length >= 1);
 
-            default: assert(false);
-        }
-    } ();
+    switch (args[0])
+    {
+        case "use":
+            enforce!HelpMsgException(args.length == 2);
+            return ActionContext(Action.Fetch | Action.Disable | Action.Enable, args[1]);
+        case "fetch":
+            enforce!HelpMsgException(args.length == 2);
+            return ActionContext(Action.Fetch, args[1]);
+        case "disable":
+            return ActionContext(Action.Disable, null);
 
-    return ActionContext(action, args[1]);
+        default: assert(false);
+    }
 }
 
 /**
@@ -80,7 +83,9 @@ void handle (ActionContext context, Path root)
             return null;
     } ();
 
-    Compiler new_compiler = compilerFromDescription(context.new_compiler, root);
+    Compiler new_compiler = context.new_compiler ?
+          compilerFromDescription(context.new_compiler, root)
+        : null;
 
     if (context.action & Action.Disable)
     {

--- a/source/dc/dc.d
+++ b/source/dc/dc.d
@@ -60,7 +60,6 @@ ActionContext parseAction (string[] args)
         }
     } ();
 
-    import dc.compilers;
     return ActionContext(action, args[1]);
 }
 
@@ -76,12 +75,12 @@ void handle (ActionContext context, Path root)
         import std.file : readText, exists;
 
         if (exists(root ~ "USED"))
-            return compiler(readText(root ~ "USED"), root);
+            return compilerFromAnchor(root ~ "USED", root);
         else
             return null;
     } ();
 
-    Compiler new_compiler = compiler(context.new_compiler, root);
+    Compiler new_compiler = compilerFromDescription(context.new_compiler, root);
 
     if (context.action & Action.Disable)
     {

--- a/source/dc/install.d
+++ b/source/dc/install.d
@@ -93,6 +93,7 @@ private void addToPath (Path bindir)
     import std.process;
     import std.algorithm.searching;
 
+    trace("Current PATH is: ", environment["PATH"]);
     if (environment["PATH"].canFind(bindir.toString()))
         return;
 

--- a/source/dc/platform/package.d
+++ b/source/dc/platform/package.d
@@ -38,7 +38,6 @@ public void initializePlatform ()
         }
 
         checkPresent("wget");
-        checkPresent("ln");
         checkPresent("tar");
 
         platform = new PosixPlatform;

--- a/source/dc/platform/posix.d
+++ b/source/dc/platform/posix.d
@@ -43,16 +43,14 @@ class PosixPlatform : Platform
     {
         mixin(traceCall());
 
-        import std.file : symlink, FileException, mkdirRecurse;
+        import std.file : mkdirRecurse;
         import std.path : dirName;
+        import std.process;
 
-        try
-        {
-            mkdirRecurse(dirName(dst));
-            symlink(src, dst);
-        }
-        catch (FileException e)
-            throw new FileFailure(dst, e.msg);
+        mkdirRecurse(dirName(dst));
+        auto result = execute([ "cp", "-r", src, dst ]);
+        if (result.status != 0)
+            throw new FileFailure(dst, result.output);
     }
 
     /// See `dc.platform.api.Platform`
@@ -60,10 +58,10 @@ class PosixPlatform : Platform
     {
         mixin(traceCall());
 
-        import std.file;
-        try
-            remove(dst);
-        catch (FileException e) {}
+        import std.process;
+        auto result = execute([ "rm", "-rf", dst ]);
+        if (result.status != 0)
+            throw new FileFailure(dst, result.output);
     }
 
     /// See `dc.platform.api.Platform`

--- a/source/dc/platform/windows.d
+++ b/source/dc/platform/windows.d
@@ -87,8 +87,10 @@ class WindowsPlatform : Platform
         mixin(traceCall());
 
         import std.format;
-        import std.exception;
+        import std.file : mkdirRecurse;
+        import std.path : dirName;
 
+        mkdirRecurse(dirName(dst));
         auto result = powershell(format(`cp -r "%s" "%s"`, src, dst));
         if (result.status != 0)
             throw new FileFailure(dst, result.stderr);

--- a/source/dc/utils/path.d
+++ b/source/dc/utils/path.d
@@ -17,7 +17,10 @@ struct Path
     this (string rhs)
     {
         this.normalized = absolutePath(expandTilde(rhs));
-        enforce(isValidPath(this.normalized));
+        enforce(
+            isValidPath(this.normalized),
+            "Not a valid path: '" ~ this.normalized ~ "'"
+        );
     }
 
     /// Quick way to append to existing path, ensures there is exactly


### PR DESCRIPTION
Stores list of all active paths in `USED` anchor file so that those can
be reliably removed even between different implementations of DC,
without having to know exact layour of each compiler version.