### PR TITLE
Make possible to get direct path to a distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ Most useful when doing cross-platform development with a lot of switching betwee
 
 This is early version and has plenty of limitations that should be eventually lifted:
 
-- No support for switching toolchain within single shell context (like
-  `activate` from `install.sh`). It doesn't fit well with DC approach of reusing
-  single `bin` folder for all versions - some design idea is needed to move
-  forward with it.
 - No shared library support. It is not yet clear how to make it work while
   keeping resulting binaries portable. Adding naive support would be trivial
   but misleading thus left out until there is any demand.

--- a/ci/test-template.yml
+++ b/ci/test-template.yml
@@ -32,3 +32,8 @@ steps:
       dc -v use ldc-1.13.0
       ldmd2 -run test/sample.d
     displayName: Verify switching compiler works (2)
+
+  - bash: |
+      export PATH=$PATH:`dc path dmd-2.082.1`
+      dmd -run test/sample.d
+    displayName: Verify switching compiler works (3)

--- a/source/dc/app.d
+++ b/source/dc/app.d
@@ -60,6 +60,7 @@ int main (string[] args)
         info("COMMAND: action to perform");
         info("\tuse - switch to specified compiler, disabling the current one if present");
         info("\tfetch - download specified compiler distribution without affecting the current one");
+        info("\tpath - print a path to distribution bindir of a given compiler");
         info("\tdisable - disable currently used compiler (but keep distribution archive)");
         info("");
         info("COMPILER: compiler description string");

--- a/source/dc/compilers/api.d
+++ b/source/dc/compilers/api.d
@@ -20,6 +20,9 @@ abstract class Compiler
     /// Disables currently enabled compiler
     void disable ();
 
+    /// Returns direct path to a portable distribution bin folder
+    Path distributionBinPath ();
+
     /// Standard text representation of this compiler description
     string representation ()
     {

--- a/source/dc/compilers/dmd.d
+++ b/source/dc/compilers/dmd.d
@@ -109,4 +109,12 @@ class DMD : Compiler
     {
         this.distribution.disable(this.config.root);
     }
+
+    override Path distributionBinPath ()
+    {
+        version (Windows)
+            return this.config.source ~ "dmd2" ~ "windows" ~ "bin";
+        else
+            return this.config.source ~ "dmd2" ~ "linux" ~ "bin64";
+    }
  }

--- a/source/dc/compilers/ldc.d
+++ b/source/dc/compilers/ldc.d
@@ -106,4 +106,18 @@ class LDC : Compiler
     {
         this.distribution.disable(this.config.root);
     }
+
+    override Path distributionBinPath ()
+    {
+        version (Windows)
+        {
+            return this.config.source ~ ("ldc2-" ~ this.config.ver ~
+                "-windows-x64") ~ "bin";
+        }
+        else version (Posix)
+        {
+            return this.config.source ~ ("ldc2-" ~ this.config.ver ~
+                "-linux-x86_64") ~ "bin";
+        }
+    }
  }


### PR DESCRIPTION
Helps to get a temporary shell modification for PATH by returning
absolute path to the binary directory that needs to be used for a given
compiler version.